### PR TITLE
Use CHEF_KEY_MATERIAL instead of deprecated CHEF_PRIVATE_KEY_FILE

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `key_material` - (Required) The PEM-formatted private key contents belonging to
   the configured client. This is issued by the server when a new client object
   is created. May be provided via the
-  ``CHEF_PRIVATE_KEY_FILE`` environment variable.
+  ``CHEF_KEY_MATERIAL`` environment variable.
 * `allow_unverified_ssl` - (Optional) Boolean indicating whether to make
   requests to a Chef server whose SSL certicate cannot be verified. Defaults
   to ``false``.


### PR DESCRIPTION
If the CHEF_PRIVATE_KEY_FILE env var is used, then a warning saying it
is deprecated is shown.

This patch just documents the new variable, so users like me don't have
to dig in the code just to see the new name of the variable.